### PR TITLE
Update parent image in Dockerfile.cpu

### DIFF
--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -1,4 +1,4 @@
-FROM conda/miniconda3
+FROM continuumio/miniconda3
 
 ENV LANG=C.UTF-8 \
     LC_ALL=C.UTF-8


### PR DESCRIPTION
I had trouble building the Dockerfile.cpu image, getting the following error:

```
$ docker build -t munkai/pytorch:cpu -f Dockerfile.cpu .
Sending build context to Docker daemon  22.66MB
Step 1/9 : FROM conda/miniconda3
 ---> 2c4c668a3586
Step 2/9 : ENV LANG=C.UTF-8     LC_ALL=C.UTF-8
 ---> Using cache
 ---> 8a9da85ad64a
Step 3/9 : RUN export CMAKE_PREFIX_PATH="$(dirname $(which conda))/../"
 ---> Using cache
 ---> 1f51e9594ff2
Step 4/9 : RUN conda install -y numpy pyyaml mkl setuptools cmake cffi
 ---> Using cache
 ---> 7d9a9fbd6ad6
Step 5/9 : RUN conda install -y pytorch-cpu torchvision-cpu -c pytorch
 ---> Running in c5f1ef1ecfd3
Traceback (most recent call last):
  File "/usr/local/bin/conda", line 12, in <module>
    from conda.cli import main
ModuleNotFoundError: No module named 'conda'
The command '/bin/sh -c conda install -y pytorch-cpu torchvision-cpu -c pytorch' returned a non-zero code: 1
```

It turned out that the conda/miniconda3 image is deprecated, see: https://github.com/conda/conda-docker
Apparently it has been replaced by: https://github.com/ContinuumIO/docker-images
Updating the parent image fixed the issue and I was able to build the image.

