### PR TITLE
Update public key for CUDA repo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Adjust as appropriate.
 DISTRO=ubuntu
 VERSION=1604
 ARCH=x86_64
-sudo apt-key adv --fetch-keys http://developer.download.nvidia.com/compute/cuda/repos/${DISTRO}${VERSION}/${ARCH}/7fa2af80.pub
+sudo apt-key adv --fetch-keys http://developer.download.nvidia.com/compute/cuda/repos/${DISTRO}${VERSION}/${ARCH}/3bf863cc.pub
 sudo sh -c 'echo "deb http://developer.download.nvidia.com/compute/cuda/repos/${DISTRO}${VERSION}/${ARCH}/" > /etc/apt/sources.list.d/cuda.list'
 sudo apt-get update && sudo apt-get install -y --no-install-recommends cuda-drivers
 ```


### PR DESCRIPTION
Keys for the CUDA package repository were rotated in April, invalidating the one currently mentioned in the README. This pull request updates the key to the current one.
Alternatively, the `cuda-keyring` package can be used, as recommended in the notice.

Link to notice about key rotation: https://forums.developer.nvidia.com/t/notice-cuda-linux-repository-key-rotation/212771